### PR TITLE
Less Job Opening For More Divesity

### DIFF
--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -5,34 +5,34 @@ Chief Engineer=1
 Research Director=1
 Chief Medical Officer=1
 
-Station Engineer=5
+Station Engineer=2
 Roboticist=1
 
-Medical Doctor=5
-Geneticist=2
+Medical Doctor=1
+Geneticist=1
 Virologist=1
 
-Scientist=3
-Chemist=2
+Scientist=1
+Chemist=1
 
 Bartender=1
-Botanist=2
+Botanist=1
 Chef=1
 Janitor=1
 Quartermaster=1
-Shaft Miner=3
+Shaft Miner=2
 Clown=1
 Mime=1
 
 Warden=1
 Detective=1
-Security Officer=5
+Security Officer=3
 
 Assistant=-1
-Atmospheric Technician=4
-Cargo Technician=3
+Atmospheric Technician=1
+Cargo Technician=1
 Chaplain=1
-Lawyer=2
+Lawyer=1
 Librarian=1
 
 AI=1


### PR DESCRIPTION
Decreases the number of job openings of certain jobs to a smaller
number, after careful consideration, to create a bigger diversity in the
roles our players to take.

Talked with a few core regulars, they are in favour of this, but I think
I still need more feedback on these changes.

The HoP can still open new positions for latejoiners if they want to
improve a department, and this will have a greater impact now.
