### PR TITLE
Irradiaton device

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -143,7 +143,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/stealthy_weapons/irradscanner
 	name = "Irradiation Device"
 	item = /obj/item/device/irradscanner
-	cost = 4
+	cost = 3
 
 // STEALTHY TOOLS
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -140,6 +140,10 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/cartridge/syndicate
 	cost = 3
 
+/datum/uplink_item/stealthy_weapons/irradscanner
+	name = "Irradiation Device"
+	item = /obj/item/device/irradscanner
+	cost = 4
 
 // STEALTHY TOOLS
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -4,6 +4,7 @@ Miscellaneous traitor devices
 
 BATTERER
 
+IRRADIATION DEVICE
 
 */
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -56,6 +56,32 @@ effective or pretty fucking useless.
 	if(times_used >= max_uses)
 		icon_state = "battererburnt"
 
+/obj/item/device/irradscanner
+	name = "Health Analyzer"
+	icon_state = "health"
+	item_state = "analyzer"
+	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
+	flags = FPRINT | TABLEPASS | CONDUCT
+	slot_flags = SLOT_BELT
+	throwforce = 3
+	w_class = 1.0
+	throw_speed = 5
+	throw_range = 10
+	m_amt = 200
+	origin_tech = "magnets=1;biotech=2;syndicate=4"
+	var/charges = 5
 
-
-
+/obj/item/device/irradscanner/attack(mob/living/M as mob, mob/living/user as mob)
+	if (!(istype(usr, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+		usr << "\red You don't have the dexterity to do this!"
+		return
+	if(charges != 0)
+		for(var/mob/O in viewers(M, null))
+			O.show_message(text("\red [] has analyzed []'s vitals!", user, M), 1)
+		M.apply_effect((rand(115, 150)), IRRADIATE, 0)
+		charges--
+		return
+	else
+		..()
+		user << "The irradiation device is out of charges!"
+		return


### PR DESCRIPTION
Adds an 'irradiation device', a traitor item disguised as a medical analyzer that costs 3 telecrystals.

When it's used on someone they get irradiated, similar to the radstorm event. This causes collapsing, slowly accumulating toxin damage, puking, and rarely mutations.

Has five uses.
