### PR TITLE
Combat+ replaced with Medflavour+

### DIFF
--- a/code/datums/limbs.dm
+++ b/code/datums/limbs.dm
@@ -131,30 +131,30 @@
 		return 1
 	return 0
 
-/datum/limb/proc/breakbone()
+/datum/limb/proc/breakbone(mob/living/carbon/human/H)
 	if(broken)
 		return 0
 
-	/var/bonename = getBoneName()
+	var/bonename = getBoneName()
 	var/breaknoise = pick("snap","crack","pop","crick","snick","click","crock","clack","crunch","snak")
-	visible_message("<span class='danger'>[src]'s [bonename] breaks with a [breaknoise]!</span>", \
+	H.visible_message("<span class='danger'>[src]'s [bonename] breaks with a [breaknoise]!</span>", \
 						"<span class='userdanger'>Your [bonename] breaks with a [breaknoise]!</span>")
 	broken = 1
 
 	return 1
 
-/datum/limb/proc/mendbone()
+/datum/limb/proc/mendbone(mob/living/carbon/human/H)
 	if(!broken)
 		return
 
 	broken = 0
 
-	/var/bonename = getBoneName()
+	var/bonename = getBoneName()
 	if(bonename == "chest")
 		bonename = "ribs"
 	else if(bonename == "head")
 		bonename = "skull"
-	src << "<span class='notice'>Your feel your broken [bonename] mend...</span>"
+	H << "<span class='notice'>Your feel your broken [bonename] mend...</span>"
 
 
 //Returns a display name for the organ

--- a/code/datums/limbs.dm
+++ b/code/datums/limbs.dm
@@ -8,6 +8,7 @@
 	var/brute_dam = 0
 	var/burn_dam = 0
 	var/max_damage = 0
+	var/broken = 0
 
 /datum/limb/chest
 	name = "chest"
@@ -130,6 +131,32 @@
 		return 1
 	return 0
 
+/datum/limb/proc/breakbone()
+	if(broken)
+		return 0
+
+	/var/bonename = getBoneName()
+	var/breaknoise = pick("snap","crack","pop","crick","snick","click","crock","clack","crunch","snak")
+	visible_message("<span class='danger'>[src]'s [bonename] breaks with a [breaknoise]!</span>", \
+						"<span class='userdanger'>Your [bonename] breaks with a [breaknoise]!</span>")
+	broken = 1
+
+	return 1
+
+/datum/limb/proc/mendbone()
+	if(!broken)
+		return
+
+	broken = 0
+
+	/var/bonename = getBoneName()
+	if(bonename == "chest")
+		bonename = "ribs"
+	else if(bonename == "head")
+		bonename = "skull"
+	src << "<span class='notice'>Your feel your broken [bonename] mend...</span>"
+
+
 //Returns a display name for the organ
 /datum/limb/proc/getDisplayName()
 	switch(name)
@@ -137,4 +164,14 @@
 		if("r_leg")		return "right leg"
 		if("l_arm")		return "left arm"
 		if("r_arm")		return "right arm"
+		else			return name
+
+/datum/limb/proc/getBoneName()
+	switch(name)
+		if("l_leg")		return "left leg"
+		if("r_leg")		return "right leg"
+		if("l_arm")		return "left arm"
+		if("r_arm")		return "right arm"
+		if("chest")		return "ribcage"
+		if("head")		return "skull"
 		else			return name

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -286,6 +286,7 @@
 	feedback_add_details("changeling_powers","CR")
 	return 1
 
+
 //Recover from stuns.
 /mob/living/carbon/proc/changeling_unstun()
 	set category = "Changeling"
@@ -422,10 +423,6 @@
 			adjustBruteLoss(-10)
 			adjustOxyLoss(-10)
 			adjustFireLoss(-10)
-			sleep(10)
-		for(var/bone in broken)
-			src << "<span class='notice'>We feel our broken [bone] mend...</span>"
-			broken -= bone
 			sleep(10)
 
 	feedback_add_details("changeling_powers","RR")

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -274,6 +274,12 @@
 	radiation = 0
 	heal_overall_damage(getBruteLoss(), getFireLoss())
 	reagents.clear_reagents()
+
+	if(istype(src,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = src
+		for(var/datum/limb/temp in H.organs)
+			temp.mendbone()
+
 	src << "<span class='notice'>We have regenerated.</span>"
 
 	status_flags &= ~(FAKEDEATH)
@@ -424,6 +430,11 @@
 			adjustOxyLoss(-10)
 			adjustFireLoss(-10)
 			sleep(10)
+
+	if(istype(src,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = src
+		for(var/datum/limb/temp in H.organs)
+			temp.mendbone()
 
 	feedback_add_details("changeling_powers","RR")
 	return 1

--- a/code/game/machinery/telepad.dm
+++ b/code/game/machinery/telepad.dm
@@ -7,6 +7,7 @@
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 50
+	var/tele_id = "placeholder"
 
 /obj/machinery/telepad_cargo
 	name = "cargo telepad"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -129,6 +129,11 @@ MASS SPECTROMETER
 				user.show_message(text("<span class='notice'>\t []: []-[]", capitalize(org.getDisplayName()), (org.burn_dam > 0) ? "<font color='#FF8000'>[org.burn_dam]</font>" : 0, (org.brute_dam > 0) ? "<font color='red'>[org.brute_dam]</font></span>" : 0), 1)
 		else
 			user.show_message("<span class='notice'>\t Limbs are OK.</span>",1)
+		for(var/datum/limb/temp in H.organs)
+			if(temp.broken)
+				var/bone_name = temp.getBoneName()
+				user.show_message(text("<span class='alert'>Warning: Subject's [bone_name] is broken.</span>"), 1)
+
 
 	// Damage descriptions
 
@@ -141,18 +146,7 @@ MASS SPECTROMETER
 		if(!D.hidden[SCANNER])
 			user.show_message(text("<span class='warning'><b>Warning: [D.form] Detected</b>\nName: [D.name].\nType: [D.spread].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure]</span>"))
 
-	var/bone_name
-	for(var/bone in M.broken)
-		if(bone == "chest")
-			bone_name = "ribs"
-		else if(bone == "head")
-			bone_name = "skull"
-		else
-			bone_name = bone
-		if(bone_name != "ribs")
-			user.show_message(text("<span class='alert'>Warning: Subject's [bone_name] is broken.</span>"), 1)
-		else
-			user.show_message(text("<span class='alert'>Warning: Subject's [bone_name] are broken.</span>"), 1)
+
 	if (M.reagents && M.reagents.get_reagent_amount("inaprovaline"))
 		user.show_message(text("<span class='notice'>Bloodstream Analysis located [M.reagents:get_reagent_amount("inaprovaline")] units of rejuvenation chemicals.</span>"), 1)
 	if (M.getBrainLoss() >= 100 || !M.getorgan(/obj/item/organ/brain))

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -834,10 +834,10 @@
 			<br>
 			<b>What Do Broken Bones <i>Do</i>?</b><br>
 			Each bone of yours has a different function, and this function will be disrupted when said bone is broken!<br>
-			<b>Broken Legs:</b> The patient will walk with a limp, and occasionally they will displace the broken bone and freeze in pain and agony! This is very detrimental to your patient's health.<br>
-			<b>Broken Arms:</b> It is hard for your patient to operate machinery and objects with their arms broken. If your patient attempts to use an object on someone, they might accidentaly displace the broken bone as well as drop what they are holding!<br>
-			<b>Broken Ribs:</b> Broken ribs will cause internal bleeding, causing the patient to slowly lose health and make it hard for them to breathe.<br>
-			<b>Broken Skull:</b> A broken skull will cause the patient to suffer short, occasional blackouts. They will also have a minor tendency of experiencing bouts of severe brain damage.<br>
+			<b>Broken Legs:</b> The patient will walk with a limp, and occasionally they will displace the broken bone!<br>
+			<b>Broken Arms:</b> It is hard for your patient to operate machinery and objects with their arms broken. If your patient attempts to use an object on someone, they might accidentaly displace the broken bone as well as drop what they are holding, if the item was hard to grip!<br>
+			<b>Broken Ribs:</b> Broken ribs will make it hard for your patients to breathe.<br>
+			<b>Broken Skull:</b> A broken skull has a minor tendency of inflicting bouts of severe brain damage.<br>
 			<br>
 			Now you know what to do! Go out there and <i>practice medicine</i>!
 			</html>"}

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -196,6 +196,7 @@
 				Paralyse(10)
 
 	var/update = 0
+	var/broke = 0
 	for(var/datum/limb/temp in organs)
 		switch(temp.name)
 			if("head")
@@ -210,29 +211,12 @@
 				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
 			if("r_leg")
 				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
-
-	var/list/bones = list("chest", "head", "left arm", "right arm", "left leg", "right leg")
-	for(var/bone in bones)
-		if(!bone in broken && prob(break_chance))
-			broken += bone
-			playsound(src, 'sound/weapons/pierce.ogg', 50)
-			if(bone == "chest")
-				bone = "ribs"
-			else if(bone == "head")
-				bone = "skull"
-			var/breaknoise = pick("snap","crack","pop","crick","snick","click","crock","clack","crunch","snak")
-			if(bone != "ribs")
-				visible_message("<span class='danger'>[src]'s [bone] breaks with a [breaknoise]!</span>", \
-								"<span class='userdanger'>Your [bone] breaks with a [breaknoise]!</span>")
-			else
-				visible_message("<span class='danger'>[src]'s [bone] break with a [breaknoise]!</span>", \
-								"<span class='userdanger'>Your [bone] break with a [breaknoise]!</span>")
-			if(break_chance >= 3)
-				break_chance -= 3
-			else
-				break_chance = 0
+		if(prob(break_chance))
+			broke |= temp.breakbone()
 
 	if(update)	update_damage_overlays(0)
+	if(broke)
+		playsound(src, 'sound/weapons/pierce.ogg', 50)
 
 /mob/living/carbon/human/blob_act()
 	if(stat == 2)	return
@@ -240,16 +224,6 @@
 	var/datum/limb/affecting = get_organ(ran_zone(dam_zone))
 	apply_damage(rand(20,30), BRUTE, affecting, run_armor_check(affecting, "melee"))
 	show_message("\red The blob attacks your [affecting]!")
-	if(prob(rand(5,10)))
-		broken += affecting
-		playsound(src, 'sound/weapons/pierce.ogg', 50)
-		var/breaknoise = pick("snap","crack","pop","crick","snick","click","crock","clack","crunch","snak")
-		if(affecting != "chest")
-			visible_message("<span class='danger'>[src]'s [affecting] breaks with a [breaknoise]!</span>", \
-							"<span class='userdanger'>Your [affecting] breaks with a [breaknoise]!</span>")
-		else
-			visible_message("<span class='danger'>[src]'s [affecting] break with a [breaknoise]!</span>", \
-							"<span class='userdanger'>Your [affecting] break with a [breaknoise]!</span>")
 	return
 
 /mob/living/carbon/human/meteorhit(O as obj)
@@ -266,16 +240,7 @@
 			if(affecting.take_damage((istype(O, /obj/effect/meteor/small) ? 10 : 25), 30))
 				update_damage_overlays(0)
 		updatehealth()
-		if(!affecting in broken) // there's no avoiding it, you got hit by a fucking meteor
-			playsound(src, 'sound/weapons/pierce.ogg', 50)
-			var/breaknoise = pick("snap","crack","pop","crick","snick","click","crock","clack","crunch","snak")
-			if(affecting != "chest")
-				visible_message("<span class='danger'>[src]'s [affecting] breaks with a [breaknoise]!</span>", \
-								"<span class='userdanger'>Your [affecting] breaks with a [breaknoise]!</span>")
-			else
-				affecting = "ribs"
-				visible_message("<span class='danger'>[src]'s [affecting] break with a [breaknoise]!</span>", \
-								"<span class='userdanger'>Your [affecting] break with a [breaknoise]!</span>")
+
 	return
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -153,7 +153,7 @@
 	var/shielded = 0
 	var/b_loss = null
 	var/f_loss = null
-	var/break_chance = 35
+	var/break_chance = 0
 
 	switch (severity)
 		if (1.0)
@@ -171,7 +171,7 @@
 		if (2.0)
 			if (!shielded)
 				b_loss += 60
-				break_chance += 35
+				break_chance += 10
 			f_loss += 60
 
 			if (prob(getarmor(null, "bomb")))
@@ -186,7 +186,7 @@
 
 		if(3.0)
 			b_loss += 15
-			break_chance += 10
+			break_chance += 25
 			if (prob(getarmor(null, "bomb")))
 				b_loss = b_loss/2
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -212,7 +212,7 @@
 			if("r_leg")
 				update |= temp.take_damage(b_loss * 0.05, f_loss * 0.05)
 		if(prob(break_chance))
-			broke |= temp.breakbone()
+			broke |= temp.breakbone(src)
 
 	if(update)	update_damage_overlays(0)
 	if(broke)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -84,7 +84,7 @@
 
 			if(!M.reagents.has_reagent("morphine") && prob(65))
 				for(var/datum/limb/temp in M.organs)
-					/var/bonename = temp.getBoneName()
+					var/bonename = temp.getBoneName()
 					if(temp.broken && bonename !="ribcage" && temp!= "skull")
 
 						if((!lying && (bonename == "left arm" || bonename == "right arm")) || (lying && (bonename == "left leg" || bonename == "right leg")))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -83,21 +83,16 @@
 				return 0
 
 			if(!M.reagents.has_reagent("morphine") && prob(65))
-				if(!lying)
-					if("left arm" in M.broken || "right arm" in M.broken)
-						M << "\red You painfully dislodge your broken arm!"
-						M.emote("scream")
-						//M.Stun(2)
-						playsound(M.loc, 'sound/weapons/pierce.ogg', 25)
-						visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
-						return 0
-				else if("left leg" in M.broken || "right leg" in M.broken)
-					M << "\red You painfully dislodge your broken leg!"
-					M.emote("scream")
-				//	M.Stun(2)
-					playsound(M.loc, 'sound/weapons/pierce.ogg', 25)
-					visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
-					return 0
+				for(var/datum/limb/temp in M.organs)
+					/var/bonename = temp.getBoneName()
+					if(temp.broken && bonename !="ribcage" && temp!= "skull")
+
+						if((!lying && (bonename == "left arm" || bonename == "right arm")) || (lying && (bonename == "left leg" || bonename == "right leg")))
+							M << "\red You painfully dislodge your broken [bonename]!"
+							playsound(M.loc, 'sound/weapons/pierce.ogg', 25)
+							M.emote("scream")
+							visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
+							return 0
 
 			var/datum/limb/affecting = get_organ(ran_zone(M.zone_sel.selecting))
 			var/armor_block = run_armor_check(affecting, "melee")
@@ -126,25 +121,7 @@
 
 			if(can_break && prob(10))
 				// HULK SMASH
-				var/hit_area = parse_zone(affecting.name)
-				if(hit_area in broken)
-					return
-				var/hit_name
-				if(hit_area == "head")
-					hit_name = "skull"
-				else if(hit_area == "chest")
-					hit_name = "ribs"
-				else
-					hit_name = hit_area
-				broken += hit_area
-				playsound(src, 'sound/weapons/pierce.ogg', 50)
-				var/breaknoise = pick("snap","crack","pop","crick","snick","click","crock","clack","crunch","snak")
-				if(affecting != "chest")
-					visible_message("<span class='danger'>[src]'s [hit_name] breaks with a [breaknoise]!</span>", \
-									"<span class='userdanger'>Your [hit_name] breaks with a [breaknoise]!</span>")
-				else
-					visible_message("<span class='danger'>[src]'s [hit_name] break with a [breaknoise]!</span>", \
-									"<span class='userdanger'>Your [hit_name] break with a [breaknoise]!</span>")
+				affecting.breakbone()
 
 		if("disarm")
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Disarmed [src.name] ([src.ckey])</font>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -68,6 +68,8 @@
 						attack_verb = "scratch"
 					if("plant")
 						attack_verb = "slash"
+					if("skeleton")
+						attack_verb = "scares"
 
 			var/damage = rand(0, 9)
 			if(!damage)
@@ -85,14 +87,14 @@
 					if("left arm" in M.broken || "right arm" in M.broken)
 						M << "\red You painfully dislodge your broken arm!"
 						M.emote("scream")
-						M.Stun(2)
+						//M.Stun(2)
 						playsound(M.loc, 'sound/weapons/pierce.ogg', 25)
 						visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
 						return 0
 				else if("left leg" in M.broken || "right leg" in M.broken)
 					M << "\red You painfully dislodge your broken leg!"
 					M.emote("scream")
-					M.Stun(2)
+				//	M.Stun(2)
 					playsound(M.loc, 'sound/weapons/pierce.ogg', 25)
 					visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
 					return 0
@@ -119,10 +121,8 @@
 								"<span class='userdanger'>[M] has weakened [src]!</span>")
 				apply_effect(4, WEAKEN, armor_block)
 				forcesay(hit_appends)
-				gasping = 2
 			else if(lying)
 				forcesay(hit_appends)
-				gasping = 2
 
 			if(can_break && prob(10))
 				// HULK SMASH
@@ -161,7 +161,6 @@
 				visible_message("<span class='danger'>[M] has pushed [src]!</span>",
 								"<span class='userdanger'>[M] has pushed [src]!</span>")
 				forcesay(hit_appends)
-				gasping = 2
 				return
 
 			if(randn <= 45)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -35,7 +35,7 @@ emp_act
 				return -1 // complete projectile permutation
 
 	if(istype(P, /obj/item/projectile/bullet))
-		gasping = 2
+		forcesay(hit_appends)
 
 	if(check_shields(P.damage, "the [P.name]"))
 		P.on_hit(src, 2)
@@ -125,24 +125,26 @@ emp_act
 		if(arm == l_hand && "left arm" in user.broken)
 			user << "\red You painfully dislodge your broken left arm!"
 			user.emote("scream")
-			user.Stun(2)
-			user.Weaken(2)
+			//user.Stun(2)
+			//user.Weaken(2)
 			var/datum/limb/larm = get_organ("l_arm")
 			user.apply_damage(rand(2,7), BRUTE, larm)
 			playsound(user.loc, 'sound/weapons/pierce.ogg', 25)
 			visible_message("<span class='warning'>[user] has attempted to attack [src] with [I]!</span>")
-			user.drop_item()
+			if(I && I.w_class == 1)
+				user.drop_item()
 			return 0
 		else if(arm == r_hand && "right arm" in user.broken)
 			user << "\red You painfully dislodge your broken right arm!"
 			user.emote("scream")
-			user.Stun(2)
-			user.Weaken(2)
+			//user.Stun(2)
+			//user.Weaken(2)
 			var/datum/limb/rarm = get_organ("r_arm")
 			user.apply_damage(rand(2,7), BRUTE, rarm)
 			playsound(user.loc, 'sound/weapons/pierce.ogg', 25)
 			visible_message("<span class='warning'>[user] has attempted to attack [src] with [I]!</span>")
-			user.drop_item()
+			if(I && I.w_class == 1)
+				user.drop_item()
 			return 0
 
 	if(I.attack_verb.len)
@@ -222,10 +224,8 @@ emp_act
 
 		if(I.force > 10 || I.force >= 5 && prob(33))
 			forcesay(hit_appends)	//forcesay checks stat already.
-		if(I.force >= 10 && I.w_class >= 4 && prob(66))
-			gasping = 1
 
-	var/breakchance = (I.force / 4) * I.w_class
+	var/breakchance = (I.force / 5) * I.w_class-1
 	//src << "\red [breakchance]% chance of breaking."
 	if(I.damtype == BRUTE && I.w_class > 1)
 		// sticks and stones will break your bones
@@ -235,10 +235,9 @@ emp_act
 		switch(hit_area)
 			if("head")
 				hit_name = "skull"
-				breakchance /= 4
+				breakchance /= 2
 			if("chest")
 				hit_name = "ribs"
-				breakchance /= 2
 		if(!hit_name)
 			hit_name = hit_area
 			breakchance *= 1.5

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -225,7 +225,7 @@ emp_act
 		if(I.force > 10 || I.force >= 5 && prob(33))
 			forcesay(hit_appends)	//forcesay checks stat already.
 
-	var/breakchance = (I.force / 5) * I.w_class-1
+	var/breakchance = (I.force / 5) * (I.w_class-1)
 	//src << "\red [breakchance]% chance of breaking."
 	if(I.damtype == BRUTE && I.w_class > 1)
 		// sticks and stones will break your bones

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -24,11 +24,11 @@
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
-	if("left leg" in broken && !reagents.has_reagent("morphine"))
+	if("left leg" in broken && "right leg" in broken && !reagents.has_reagent("morphine"))
 		tally += 1
 
-	if("right leg" in broken && !reagents.has_reagent("morphine"))
-		tally += 1
+	/*if("right leg" in broken && !reagents.has_reagent("morphine"))
+		tally += 1*/
 
 	return (tally+config.human_delay)
 
@@ -39,8 +39,9 @@
 		if("left leg" in broken)
 			src << "\red Pain shoots up your left leg!"
 			var/datum/limb/affecting = get_organ("l_leg")
-			apply_damage(rand(2,7), BRUTE, affecting)
-			Stun(2)
+			apply_damage(rand(0,1), HALLOSS, affecting)
+			//Stun(2)
+			emote("scream")
 			playsound(src, 'sound/weapons/pierce.ogg', 25)
 			last_break = 1
 			spawn(50)
@@ -49,8 +50,9 @@
 		if("right leg" in broken)
 			src << "\red Pain shoots up your right leg!"
 			var/datum/limb/affecting = get_organ("r_leg")
-			apply_damage(rand(2,7), BRUTE, affecting)
-			Stun(2)
+			apply_damage(rand(0,1), HALLOSS, affecting)
+			//Stun(2)
+			emote("scream")
 			playsound(src, 'sound/weapons/pierce.ogg', 25)
 			last_break = 1
 			spawn(50)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -24,7 +24,7 @@
 	if (bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
-	if("left leg" in broken && "right leg" in broken && !reagents.has_reagent("morphine"))
+	if(("left leg" in broken) && ("right leg" in broken) && !reagents.has_reagent("morphine"))
 		tally += 1
 
 	/*if("right leg" in broken && !reagents.has_reagent("morphine"))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -229,7 +229,6 @@
 	proc/breathe()
 
 		if(reagents.has_reagent("lexorin")) return
-		if("chest" in broken && prob(30)) return
 		if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell)) return
 
 		var/datum/gas_mixture/environment = loc.return_air()
@@ -1243,11 +1242,16 @@
 			mind.changeling.regenerate()
 
 	proc/handle_bones()
-		if(dna && (dna.mutantrace == "slime" || dna.mutantrace == "plant"))
+		for(var/datum/limb/temp in organs)
+			if(temp.broken)
+				if(dna && (dna.mutantrace == "slime" || dna.mutantrace == "plant"))
+					temp.mendbone()
 			// ugly hack to stop slimepeople and plantpeople from breaking their nonexistant bones
-			broken = list()
-		if("head" in broken && prob(15) && getBrainLoss()<30)
-			adjustBrainLoss(1)
+			if(temp.name == "head" && prob(15) && getBrainLoss()<31)
+				adjustBrainLoss(1)
+
+			if(temp.name == "chest" && prob(35))
+				gasping++
 
 #undef HUMAN_MAX_OXYLOSS
 #undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -229,7 +229,7 @@
 	proc/breathe()
 
 		if(reagents.has_reagent("lexorin")) return
-		if("chest" in broken && prob(50)) return
+		if("chest" in broken && prob(30)) return
 		if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell)) return
 
 		var/datum/gas_mixture/environment = loc.return_air()
@@ -860,8 +860,9 @@
 
 			//Blood loss
 			var/tot_damage = maxHealth-health
-			if(getBruteLoss() >= 50 && prob(15) && tot_damage<=105 && !paralysis)
-				adjustBruteLoss(rand(2,4))
+			if(getBruteLoss() >= 50 && prob(20))
+				if(tot_damage<=105 && !paralysis)
+					adjustBruteLoss(rand(1,2))
 				var/turf/pos = get_turf(src)
 				pos.add_blood_floor(src)
 				playsound(pos, 'sound/effects/splat.ogg', 10, 1)
@@ -1139,27 +1140,29 @@
 //			if(rest)	//Not used with new UI
 //				if(resting || lying || sleeping)		rest.icon_state = "rest1"
 //				else									rest.icon_state = "rest0"
-			if(toxin && !reagents.has_reagent("morphine"))
-				if(hal_screwyhud == 4 || toxins_alert)	toxin.icon_state = "tox1"
-				else									toxin.icon_state = "tox0"
-			if(oxygen && !reagents.has_reagent("morphine"))
-				if(hal_screwyhud == 3 || oxygen_alert)	oxygen.icon_state = "oxy1"
-				else									oxygen.icon_state = "oxy0"
-			if(fire && !reagents.has_reagent("morphine"))
-				if(fire_alert)							fire.icon_state = "fire[fire_alert]" //fire_alert is either 0 if no alert, 1 for cold and 2 for heat.
-				else									fire.icon_state = "fire0"
 
-			if(bodytemp && !reagents.has_reagent("morphine"))
-				switch(bodytemperature) //310.055 optimal body temp
-					if(370 to INFINITY)		bodytemp.icon_state = "temp4"
-					if(350 to 370)			bodytemp.icon_state = "temp3"
-					if(335 to 350)			bodytemp.icon_state = "temp2"
-					if(320 to 335)			bodytemp.icon_state = "temp1"
-					if(300 to 320)			bodytemp.icon_state = "temp0"
-					if(295 to 300)			bodytemp.icon_state = "temp-1"
-					if(280 to 295)			bodytemp.icon_state = "temp-2"
-					if(260 to 280)			bodytemp.icon_state = "temp-3"
-					else					bodytemp.icon_state = "temp-4"
+			if(!reagents.has_reagent("morphine"))
+				if(toxin)
+					if(hal_screwyhud == 4 || toxins_alert)	toxin.icon_state = "tox1"
+					else									toxin.icon_state = "tox0"
+				if(oxygen)
+					if(hal_screwyhud == 3 || oxygen_alert)	oxygen.icon_state = "oxy1"
+					else									oxygen.icon_state = "oxy0"
+				if(fire)
+					if(fire_alert)							fire.icon_state = "fire[fire_alert]" //fire_alert is either 0 if no alert, 1 for cold and 2 for heat.
+					else									fire.icon_state = "fire0"
+
+				if(bodytemp)
+					switch(bodytemperature) //310.055 optimal body temp
+						if(370 to INFINITY)		bodytemp.icon_state = "temp4"
+						if(350 to 370)			bodytemp.icon_state = "temp3"
+						if(335 to 350)			bodytemp.icon_state = "temp2"
+						if(320 to 335)			bodytemp.icon_state = "temp1"
+						if(300 to 320)			bodytemp.icon_state = "temp0"
+						if(295 to 300)			bodytemp.icon_state = "temp-1"
+						if(280 to 295)			bodytemp.icon_state = "temp-2"
+						if(260 to 280)			bodytemp.icon_state = "temp-3"
+						else					bodytemp.icon_state = "temp-4"
 
 //	This checks how much the mob's eyewear impairs their vision
 			if(tinttotal >= TINT_IMPAIR)
@@ -1240,20 +1243,11 @@
 			mind.changeling.regenerate()
 
 	proc/handle_bones()
-		if("chest" in broken)
-			// internal bleeding(?)
-			var/datum/limb/affecting = get_organ("chest")
-			if(prob(65))
-				apply_damage(1, BRUTE, affecting)
-		if("head" in broken)
-			if(prob(5) && stat == CONSCIOUS)
-				sleeping = 2
-				adjustBruteLoss(2)
-			if(prob(25))
-				adjustBrainLoss(1)
 		if(dna && (dna.mutantrace == "slime" || dna.mutantrace == "plant"))
 			// ugly hack to stop slimepeople and plantpeople from breaking their nonexistant bones
 			broken = list()
+		if("head" in broken && prob(15) && getBrainLoss()<30)
+			adjustBrainLoss(1)
 
 #undef HUMAN_MAX_OXYLOSS
 #undef HUMAN_CRIT_MAX_OXYLOSS

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -264,7 +264,6 @@
 	ear_damage = 0
 	heal_overall_damage(1000, 1000)
 	buckled = initial(src.buckled)
-	broken = list()
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
 		C.handcuffed = initial(C.handcuffed)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1141,10 +1141,9 @@ datum
 					M.adjustOxyLoss(-3)
 					M.heal_organ_damage(3,3)
 					M.adjustToxLoss(-3)
-					for(var/b in M.broken)
+					for(var/datum/limb/temp in M.organs)
 						if(prob(7))
-							M << "<span class='notice'>You feel your broken [b] mend...</span>"
-							M.broken -= b
+							temp.mendbone()
 							M.adjustBruteLoss(-5)
 				..()
 				return
@@ -1164,11 +1163,11 @@ datum
 					M.heal_organ_damage(3,3)
 					M.adjustToxLoss(-3)
 					M.status_flags &= ~DISFIGURED
-					for(var/b in M.broken)
+					for(var/datum/limb/temp in M.organs)
 						if(prob(14))
-							M << "<span class='notice'>You feel your broken [b] mend...</span>"
-							M.broken -= b
+							temp.mendbone()
 							M.adjustBruteLoss(-5)
+
 				..()
 				return
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1283,10 +1283,15 @@ datum
 		morphine
 			name = "Morphine"
 			id = "morphine"
-			description = "A drug that relieves pain but does not heal any damage. It will prevent limping and adverse effects caused by the pain of having a broken bone."
+			description = "A drug that relieves pain. It will prevent limping and adverse effects caused by the pain of having a broken bone."
 			reagent_state = LIQUID
 			color = "#EEEEEE"
 
+			on_mob_life(var/mob/living/M as mob)
+				if(!M) M = holder.my_atom
+				M.adjustHalLoss(-5);
+				..()
+				return
 //////////////////////////Poison stuff///////////////////////
 
 		toxin


### PR DESCRIPTION
*stuns removed from bones
*gasping removed in some places, replaced with forcesay. Gasping left in
the code, in case someone makes CHOKE BULLETS or garrottes.
*broken arms only drop small items, same reason as coughing. .
*break chance reworked: less easy to do now, but raised rib and skull
chances. The reward is lesser, though.
*bone slowdown stacked too well with low damage. Now you need both legs
to be broken
*no stuns per step, damage is now very low hal_loss
*chest wounds won't do endless damage, but they'll still suffocate you
*you are damaged by bleeding less, but you can still bleed for flavour
fun
*morphine heals hallucination damage
*on life.dm, there was a series of IF statements, each checking for
morphine one by one: standardized it.
*no blackouts on skulls, brainloss won't go into insanity category

*placeholder tele_id for telepads

MOST IMPORTANT CHANGE
*skeletons's attack message changed. "Cool Skeleton scares McUrist in
the left leg!"
