### PR TITLE
Double Steal Tweak

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -130,10 +130,12 @@
 				steal_objective.find_target()
 				traitor.objectives += steal_objective
 
-				steal_objective = new
-				steal_objective.owner = traitor
-				steal_objective.find_target()
-				traitor.objectives += steal_objective
+				if(num_players()<12)
+					steal_objective = new
+					steal_objective.owner = traitor
+					steal_objective.find_target()
+					traitor.objectives += steal_objective
+
 		switch(rand(1,100))
 			if(1 to 25)
 				var/datum/objective/assassinate/kill_objective = new

--- a/code/game/machinery/computer/telescience.dm
+++ b/code/game/machinery/computer/telescience.dm
@@ -213,8 +213,8 @@
 	if(href_list["recal"])
 		if(telepad == null)
 			for(var/obj/machinery/telepad/T in range(src,10))
-				if(T.tele_id == tele_id)
-					telepad = T
+				//if(T.tele_id == tele_id)
+				telepad = T
 		if(!telepad)	return
 		var/teleturf = get_turf(telepad)
 		teles_left = rand(8,12)


### PR DESCRIPTION
The DoubleSteal objective adds only one steal objective when we have
more than 13 players. Above that, we should have enough traitors to
cause chaos.

Still need the telepad fix too.
