### PR TITLE
No Windedness

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -68,6 +68,8 @@
 						attack_verb = "scratch"
 					if("plant")
 						attack_verb = "slash"
+					if("skeleton")
+						attack_verb = "scares"
 
 			var/damage = rand(0, 9)
 			if(!damage)
@@ -119,10 +121,8 @@
 								"<span class='userdanger'>[M] has weakened [src]!</span>")
 				apply_effect(4, WEAKEN, armor_block)
 				forcesay(hit_appends)
-				gasping = 2
 			else if(lying)
 				forcesay(hit_appends)
-				gasping = 2
 
 			if(can_break && prob(10))
 				// HULK SMASH
@@ -161,7 +161,6 @@
 				visible_message("<span class='danger'>[M] has pushed [src]!</span>",
 								"<span class='userdanger'>[M] has pushed [src]!</span>")
 				forcesay(hit_appends)
-				gasping = 2
 				return
 
 			if(randn <= 45)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -230,8 +230,6 @@ emp_act
 
 		if(I.force > 10 || I.force >= 5 && prob(33))
 			forcesay(hit_appends)	//forcesay checks stat already.
-		if(I.force >= 10 && I.w_class >= 4 && prob(66))
-			gasping = 1
 
 	var/breakchance = (I.force / 4) * I.w_class
 	//src << "\red [breakchance]% chance of breaking."

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -941,8 +941,6 @@
 			if(druggy)
 				druggy = max(druggy-1, 0)
 
-			if(gasping)
-				gasping--
 		return 1
 
 	proc/handle_regular_hud_updates()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -6,11 +6,6 @@
 	// Needed so when they die they can talk in dead chat normally without needing to ghost.
 	if(stat != DEAD)
 
-		if(gasping)	// sometimes you get winded by blunt objects or bullets
-			if(length(message) >= 1)
-				emote("gasp")
-				return
-
 		//Mimes dont speak! Changeling hivemind and emotes are allowed.
 		if(!IsVocal())
 			if(length(message) >= 2)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -12,11 +12,10 @@
 */
 
 /mob/living
-	// broken bones & gasping
+	// broken bones
 	// note: these are only here to avoid rewriting a lot of code
 	// these only do stuff if you are a human
 	var/list/broken = list()
-	var/gasping = 0
 
 /mob/living/proc/run_armor_check(def_zone = null, attack_flag = "melee", absorb_text = null, soften_text = null)
 	var/armor = getarmor(def_zone, attack_flag)


### PR DESCRIPTION
Removes Windedness.

All instances in the code already called Forcesay, making it superflous and just annoying.

Includes important skeleton attack change.
