### PR TITLE
Nerfs windoor health

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/doors/windoor.dmi'
 	icon_state = "left"
 	var/base_state = "left"
-	var/health = 150.0 //If you change this, consiter changing ../door/window/brigdoor/ health at the bottom of this .dm file
+	var/health = 80.0 //If you change this, consiter changing ../door/window/brigdoor/ health at the bottom of this .dm file
 	visible = 0.0
 	use_power = 0
 	flags = ON_BORDER
@@ -237,7 +237,7 @@
 	base_state = "leftsecure"
 	req_access = list(access_security)
 	var/id = null
-	health = 300.0 //Stronger doors for prison (regular window door health is 200)
+	health = 160.0 //Stronger doors for prison (regular window door health is 200)
 
 
 /obj/machinery/door/window/northleft


### PR DESCRIPTION
Previously, windoors had an insanely high amount of health that made
them impossible to break. This makes it slightly easier, considering
that are not used all that often.
