### PR TITLE
Replaces 'donk' with 'clong'

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -17,7 +17,7 @@ obj/machinery/atmospherics
 	power_channel = ENVIRON
 	var/nodealert = 0
 	var/can_unwrench = 0
-
+	var/clong = 0
 
 
 obj/machinery/atmospherics/var/initialize_directions = 0

--- a/code/modules/mob/living/ventcrawl.dm
+++ b/code/modules/mob/living/ventcrawl.dm
@@ -12,9 +12,13 @@
 	if(user.stat || !isturf(src.loc))
 		return
 	if(!(mdir&initialize_directions))
-		visible_message(pick("clang","CLANG","Clang","clong","CLONG","Clong","tink","tak","tok","DOK","DAK"))
-		user << "donk" // find the user and put a donk on it
-		user.Stun(1)
+		if(user.stat)
+			return
+		if(!clong)
+			playsound(src.loc, 'sound/effects/clang.ogg', 50, 0, 0)
+			clong = 1
+			sleep(30)
+			clong = 0
 		return
 	var/turf/T = get_step(loc,mdir)
 	var/fromdir = turn(mdir,180)


### PR DESCRIPTION
It is sad, but necessary.

Instead of outputting 'donk' in the text, it actually makes a noise, but on a cooldown.
