### PR TITLE
Antag scaling changes

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -45,13 +45,11 @@
 				possible_changelings -= player
 				possible_traitors -= player
 
-	//if(config.traitor_scaling)
-	//traitors_possible = scale_antags()
+	if(config.traitor_scaling_coeff)
+		traitors_possible = max(1, round((num_players())/(config.traitor_scaling_coeff)))
+	else
+		traitors_possible = max(1, min(num_players(), traitors_possible))
 
-	// No more than three lings, but allow them to be a
-	// greater portion of the antagonist docket if the
-	// dice land like that.
-	//var/num_changelings = min(3,rand(1,traitors_possible-1))
 
 	while(possible_changelings.len && (changelings.len < num_changelings))
 		var/datum/mind/changeling = pick_n_take(possible_changelings)
@@ -59,7 +57,7 @@
 		modePlayer += changeling
 		possible_traitors -= changeling
 
-	while(possible_traitors.len && (modePlayer.len < traitors_possible))
+	while(possible_traitors.len && (traitors.len < traitors_possible))
 		var/datum/mind/traitor = pick_n_take(possible_traitors)
 		traitors += traitor
 		modePlayer += traitor

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,7 +5,7 @@
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 9 // 20 players - 5 players to be the nuke ops = 15 players remaining
+	required_players = 12 // 20 players - 5 players to be the nuke ops = 15 players remaining
 	required_enemies = 1
 	recommended_enemies = 5
 	pre_setup_before_jobs = 1

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -9,7 +9,7 @@
 	traitor_name = "double agent"
 
 	traitors_possible = 8 //hard limit on traitors if scaling is turned off
-	scale_modifier = 0.5 // Nearly twice as many double agents
+	scale_modifier = 0.6 // Nearly 1.5 times as many double agents
 
 	var/list/target_list = list()
 	var/list/late_joining_list = list()


### PR DESCRIPTION
1, Makes traitors in traitorchan scale properly, instead of always
creating (5-numberoflings) traitors like in last round. It would be
easier if we just called a ..() for traitor scaling but then we could
have lingtraitors...
2, Decreased doubleagents amount just a bit, by popular demand
3, Increased the number of players required for Nuke, so the OPs won't
be forever alone ;-;
