### PR TITLE
Numb morphine

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -290,9 +290,11 @@
 		if(resting)
 			dizziness = max(0, dizziness - 5)
 			jitteriness = max(0, jitteriness - 5)
+			numbness = max(0, numbness -5)
 		else
 			dizziness = max(0, dizziness - 1)
 			jitteriness = max(0, jitteriness - 1)
+			numbness = max(0, numbness -1)
 
 		updatehealth()
 

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -207,9 +207,11 @@
 		if(resting)
 			dizziness = max(0, dizziness - 5)
 			jitteriness = max(0, jitteriness - 5)
+			numbness = max(0, numbness - 5)
 		else
 			dizziness = max(0, dizziness - 1)
 			jitteriness = max(0, jitteriness - 1)
+			numbness = max(0, numbness -5)
 
 		updatehealth()
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -19,6 +19,7 @@
 	stat = DEAD
 	dizziness = 0
 	jitteriness = 0
+	numbness = 0
 
 	if(istype(loc, /obj/mecha))
 		var/obj/mecha/M = loc

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -206,7 +206,7 @@
 
 	var/list/bones = list("chest", "head", "left arm", "right arm", "left leg", "right leg")
 	for(var/bone in bones)
-		if(!bone in broken && prob(break_chance))
+		if(!(bone in broken) && prob(break_chance))
 			broken += bone
 			playsound(src, 'sound/weapons/pierce.ogg', 50)
 			if(bone == "chest")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -85,12 +85,13 @@
 				visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
 				return 0
 
-			if(!M.reagents.has_reagent("morphine") && prob(65))
+			if(!M.numbness && prob(65))
 				if(!lying)
 					if("left arm" in M.broken || "right arm" in M.broken)
 						M << "\red You painfully dislodge your broken arm!"
 						M.emote("scream")
 					//	M.Stun(2)
+						M.adjustStaminaLoss(5)
 						playsound(M.loc, 'sound/weapons/pierce.ogg', 25)
 					//	visible_message("<span class='warning'>[M] has attempted to [attack_verb] [src]!</span>")
 					//	return 0

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -127,14 +127,13 @@ emp_act
 
 	// Broken arms are no good for combat!
 	var/arm = user.get_active_hand()
-	if(!user.reagents.has_reagent("morphine") && prob(35))
+	if(!user.numbness && prob(35))
 		if(arm == l_hand && "left arm" in user.broken)
 			user << "\red You painfully dislodge your broken left arm!"
 			user.emote("scream")
 		//	user.Stun(2)
 		//	user.Weaken(2)
-			var/obj/item/organ/limb/larm = get_organ("l_arm")
-			user.apply_damage(rand(1,2), STAMINA, larm)
+			user.adjustStaminaLoss(5)
 			playsound(user.loc, 'sound/weapons/pierce.ogg', 25)
 		//	visible_message("<span class='warning'>[user] has attempted to attack [src] with [I]!</span>")
 		//	user.drop_item()
@@ -144,8 +143,7 @@ emp_act
 			user.emote("scream")
 		//	user.Stun(2)
 	//		user.Weaken(2)
-			var/obj/item/organ/limb/rarm = get_organ("r_arm")
-			user.apply_damage(rand(1,2), STAMINA, rarm)
+			user.adjustStaminaLoss(5)
 			playsound(user.loc, 'sound/weapons/pierce.ogg', 25)
 	//		visible_message("<span class='warning'>[user] has attempted to attack [src] with [I]!</span>")
 	//		user.drop_item()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -6,7 +6,7 @@
 
 	. = 0
 	var/health_deficiency = (100 - health + staminaloss)
-	if(health_deficiency >= 40 && !reagents.has_reagent("morphine"))
+	if(health_deficiency >= 40 && !numbness)
 		. += (health_deficiency / 25)
 
 	var/hungry = (500 - nutrition) / 5	//So overeat would be 100 and default level would be 80
@@ -27,7 +27,7 @@
 	if(bodytemperature < 283.222)
 		. += (283.222 - bodytemperature) / 10 * 1.75
 
-	if(("left leg" in broken) && ("right leg" in broken) && !reagents.has_reagent("morphine"))
+	if(("left leg" in broken) && ("right leg" in broken) && !numbness)
 		. += 1
 
 	return (. +config.human_delay)
@@ -35,11 +35,10 @@
 /mob/living/carbon/human/Move()
 	// ugh this looks so ugly
 	var/last_break = 0
-	if(prob(2) && !reagents.has_reagent("morphine") && !last_break)
+	if(prob(2) && !numbness && !last_break)
 		if("left leg" in broken)
 			src << "\red Pain shoots up your left leg!"
-			var/obj/item/organ/limb/affecting = get_organ("l_leg")
-			apply_damage(rand(0,2), STAMINA, affecting)
+			adjustStaminaLoss(10)
 		//	Stun(2)
 			playsound(src, 'sound/weapons/pierce.ogg', 25)
 			last_break = 1
@@ -48,8 +47,7 @@
 			return
 		if("right leg" in broken)
 			src << "\red Pain shoots up your right leg!"
-			var/obj/item/organ/limb/affecting = get_organ("r_leg")
-			apply_damage(rand(0,2), STAMINA, affecting)
+			adjustStaminaLoss(10)
 		//	Stun(2)
 			playsound(src, 'sound/weapons/pierce.ogg', 25)
 			last_break = 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -814,9 +814,11 @@
 		if(resting)
 			dizziness = max(0, dizziness - 15)
 			jitteriness = max(0, jitteriness - 15)
+			numbness = max(0, numbness - 15)
 		else
 			dizziness = max(0, dizziness - 3)
 			jitteriness = max(0, jitteriness - 3)
+			numbness = max(0, numbness -3)
 
 		updatehealth()
 
@@ -865,7 +867,7 @@
 			//Blood loss
 			//var/tot_damage = maxHealth-health
 			if(getBruteLoss() >= 50 && prob(15) && !paralysis)
-				adjustStaminaLoss(rand(0,1))
+				adjustStaminaLoss(5)
 				var/turf/pos = get_turf(src)
 				pos.add_blood_floor(src)
 				playsound(pos, 'sound/effects/splat.ogg', 10, 1)
@@ -1036,7 +1038,7 @@
 						I.icon_state = "oxydamageoverlay6"
 					if(45 to INFINITY)
 						I.icon_state = "oxydamageoverlay7"
-				if(!reagents.has_reagent("morphine"))
+				if(!numbness)
 					damageoverlay.overlays += I
 
 			//Fire and Brute damage overlay (BSSR)
@@ -1058,7 +1060,7 @@
 						I.icon_state = "brutedamageoverlay5"
 					if(85 to INFINITY)
 						I.icon_state = "brutedamageoverlay6"
-				if(!reagents.has_reagent("morphine"))
+				if(!numbness)
 					var/image/black = image(I.icon, I.icon_state) //BLEND_ADD doesn't let us darken, so this is just to blacken the edge of the screen
 					black.color = "#170000"
 					damageoverlay.overlays += I
@@ -1138,7 +1140,7 @@
 					if(1)	healths.icon_state = "health0"
 					if(2)	healths.icon_state = "dead"
 					else
-						if(!reagents.has_reagent("morphine"))
+						if(!numbness)
 							switch(health - staminaloss)
 								if(100 to INFINITY)		healths.icon_state = "health10"
 								if(90 to 100)			healths.icon_state = "health9"
@@ -1160,7 +1162,7 @@
 					if(150 to 250)					nutrition_icon.icon_state = "nutrition3"
 					else							nutrition_icon.icon_state = "nutrition4"
 
-			if(pressure && !reagents.has_reagent("morphine"))
+			if(pressure && !numbness)
 				pressure.icon_state = "pressure[pressure_alert]"
 
 			if(pullin)
@@ -1169,17 +1171,17 @@
 //			if(rest)	//Not used with new UI
 //				if(resting || lying || sleeping)		rest.icon_state = "rest1"
 //				else									rest.icon_state = "rest0"
-			if(toxin && !reagents.has_reagent("morphine"))
+			if(toxin && !numbness)
 				if(hal_screwyhud == 4 || toxins_alert)	toxin.icon_state = "tox1"
 				else									toxin.icon_state = "tox0"
-			if(oxygen && !reagents.has_reagent("morphine"))
+			if(oxygen && !numbness)
 				if(hal_screwyhud == 3 || oxygen_alert)	oxygen.icon_state = "oxy1"
 				else									oxygen.icon_state = "oxy0"
-			if(fire && !reagents.has_reagent("morphine"))
+			if(fire && !numbness)
 				if(fire_alert)							fire.icon_state = "fire[fire_alert]" //fire_alert is either 0 if no alert, 1 for cold and 2 for heat.
 				else									fire.icon_state = "fire0"
 
-			if(bodytemp && !reagents.has_reagent("morphine"))
+			if(bodytemp && !numbness)
 				switch(bodytemperature) //310.055 optimal body temp
 					if(370 to INFINITY)		bodytemp.icon_state = "temp4"
 					if(350 to 370)			bodytemp.icon_state = "temp3"
@@ -1265,10 +1267,8 @@
 
 	proc/handle_bones()
 		if("chest" in broken)
-			// internal bleeding(?)
-			var/obj/item/organ/limb/affecting = get_organ("chest")
 			if(prob(65))
-				apply_damage(1, STAMINA, affecting)
+				adjustStaminaLoss(2)
 		if("head" in broken)
 			//if(prob(5) && stat == CONSCIOUS)
 				//sleeping = 2

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -720,6 +720,9 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/Dizzy(amount)
 	dizziness = max(dizziness,amount,0)
 
+/mob/proc/Numb(amount)
+	numbness = max(numbness,amount,0)
+
 /mob/proc/Stun(amount)
 	if(status_flags & CANSTUN)
 		stunned = max(stunned,amount,0) //can't go below 0, getting a low amount of stun doesn't lower your current stun

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -75,6 +75,7 @@
 	var/drowsyness = 0//Carbon
 	var/dizziness = 0//Carbon
 	var/jitteriness = 0//Carbon
+	var/numbness = 0//Carbon
 	var/nutrition = 400//Carbon
 
 	var/overeatduration = 0		// How long this guy is overeating //Carbon

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1157,10 +1157,10 @@ datum
 					M.heal_organ_damage(3,3)
 					M.adjustToxLoss(-3)
 					for(var/b in M.broken)
-						if(prob(7))
+						if(prob(30))
 							M << "<span class='notice'>You feel your broken [b] mend...</span>"
 							M.broken -= b
-							M.adjustBruteLoss(-5)
+							break
 				..()
 				return
 
@@ -1180,10 +1180,10 @@ datum
 					M.adjustToxLoss(-3)
 					M.status_flags &= ~DISFIGURED
 					for(var/b in M.broken)
-						if(prob(14))
+						if(prob(60))
 							M << "<span class='notice'>You feel your broken [b] mend...</span>"
 							M.broken -= b
-							M.adjustBruteLoss(-5)
+							break
 				..()
 				return
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1305,6 +1305,7 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				M.adjustStaminaLoss(-1*REM)
+				M.Numb(10)
 				..()
 				return
 


### PR DESCRIPTION
Replacess the dozen or so consequitive "does this person has morphine in
their blood" checks per tick with a numbness variable.
Morphine causes numbness. The effect wears off fast, roughly synches with the amount of morphine in your system. 
Increased Staminadamage of bones and bleeding. Made them applied directly, because in some places the calls used the proc that included armor in the damage calculation
Cryo and Clonax has a drastically greater chance of mending bones (only one bone per tick per chemical). Placeholder fix until I make a dedicated bone surgery/chemical. 
Fixes a few unencapsulated "x in y" checks. They were if(!x in y) instead of if(!(x in y))
