### PR TITLE
Supply cleanup

### DIFF
--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -314,18 +314,19 @@ var/global/datum/controller/supply_shuttle/supply_shuttle
 
 						if(T.stored  && T.stored.id && T.stored.level > 1 ) //you only get money for high level and nonempty disks
 							if(knownTech[T.stored.id])
-								T.stored = 0
-								if(T.stored.level > knownTech[T.stored.id] ) //)
-									var/techDiff = T.stored.level - knownTech[T.stored.id]
+								if(T.stored.level > knownTech[T.stored.id] + 1 ) //)
+									var/techDiff = T.stored.level - (knownTech[T.stored.id]+1)
 									var/pointGain = techDiff*points_per_tech
-									centcom_message += "<font color=green>+[pointGain]</font>: New levels of \"[capitalize(T.stored.id)]\" processed.<BR>"
+									centcom_message += "<font color=green>+[pointGain]</font>: New levels of \"[capitalize(T.stored.name)]\" processed.<BR>"
+									knownTech[T.stored.id] = T.stored.level
 									points += pointGain
 								else
-									centcom_message += "<font color=red>+0</font>: Disk technology did not exceed the previous levels of \"[capitalize(T.stored.id)]\".<BR>"
+									centcom_message += "<font color=red>+0</font>: Disk technology did not exceed the previous levels of \"[capitalize(T.stored.name)]\".<BR>"
 
 							else
-								var/pointGain = T.stored.level*points_per_tech
-								centcom_message += "<font color=green>+[pointGain]</font>: New technology processed: \"[capitalize(T.stored.id)]\".<BR>"
+								var/pointGain = (T.stored.level-1)*points_per_tech
+								centcom_message += "<font color=green>+[pointGain]</font>: New technology processed: \"[capitalize(T.stored.name)]\".<BR>"
+								knownTech[T.stored.id] = T.stored.level
 								points += pointGain
 						else
 							centcom_message += "<font color=red>+0</font>: Disk contained no new technologies.<BR>"

--- a/code/controllers/supply_shuttle.dm
+++ b/code/controllers/supply_shuttle.dm
@@ -5,7 +5,6 @@
 #define SUPPLY_DOCK_AREATYPE "/area/supply/dock"	//Type of the supply shuttle area for dock
 
 var/global/datum/controller/supply_shuttle/supply_shuttle
-var/list/known_tech = list()
 
 /area/supply/station //DO NOT TURN THE lighting_use_dynamic STUFF ON FOR SHUTTLES. IT BREAKS THINGS.
 	name = "supply shuttle"
@@ -123,11 +122,12 @@ var/list/known_tech = list()
 	var/points_per_slip = 2
 	var/points_per_crate = 5
 	var/plasma_per_point = 0.2 //5 points per plasma sheet due to increased rarity
-	var/points_per_tech = 6 // placeholder for now
-	var/plant_per_point = 5
+	var/points_per_tech = 6 // points for new technologies
 	var/centcom_message = "" // Remarks from Centcom on how well you checked the last order.
 	// Unique typepaths for unusual things we've already sent CentComm, associated with their potencies
 	var/list/discoveredPlants = list()
+	// Technologies sent to Centcom
+	var/list/knownTech = list()
 	//control
 	var/ordernum
 	var/list/shoppinglist = list()
@@ -232,8 +232,6 @@ var/list/known_tech = list()
 
 		var/plasma_count = 0
 		var/crate_count = 0
-		var/tech_count = 0
-		var/plant_count = 0
 
 		centcom_message = ""
 
@@ -313,21 +311,26 @@ var/list/known_tech = list()
 					//Sell tech
 					if(istype(A, /obj/item/weapon/disk/tech_disk))
 						var/obj/item/weapon/disk/tech_disk/T = A
-						var/unknown_tech = 1
-						if(T.stored && T.stored.level!=1) //you only got money for high level and nonempty disks
-							for(var/datum/tech/KT in known_tech)
-								if(KT.id == T.stored.id)
-									tech_count += max(0,T.stored.level-KT.level) //check if the tech is new
-									KT.level = max(KT.level, T.stored.level) //updating old tech
-									unknown_tech = 0
-							if(unknown_tech)
-								tech_count += T.stored.level-1 //new tech, minus the base level of 1
-								known_tech += T.stored
+
+						if(T.stored  && T.stored.id && T.stored.level > 1 ) //you only get money for high level and nonempty disks
+							if(knownTech[T.stored.id])
+								T.stored = 0
+								if(T.stored.level > knownTech[T.stored.id] ) //)
+									var/techDiff = T.stored.level - knownTech[T.stored.id]
+									var/pointGain = techDiff*points_per_tech
+									centcom_message += "<font color=green>+[pointGain]</font>: New levels of \"[capitalize(T.stored.id)]\" processed.<BR>"
+									points += pointGain
+								else
+									centcom_message += "<font color=red>+0</font>: Disk technology did not exceed the previous levels of \"[capitalize(T.stored.id)]\".<BR>"
+
+							else
+								var/pointGain = T.stored.level*points_per_tech
+								centcom_message += "<font color=green>+[pointGain]</font>: New technology processed: \"[capitalize(T.stored.id)]\".<BR>"
+								points += pointGain
+						else
+							centcom_message += "<font color=red>+0</font>: Disk contained no new technologies.<BR>"
 
 
-					//Sell plants
-					if(istype(A,/obj/item/weapon/reagent_containers/food/snacks/grown/))
-						plant_count += 1
 
 			qdel(MA)
 
@@ -339,13 +342,6 @@ var/list/known_tech = list()
 			centcom_message += "<font color=green>+[round(crate_count*points_per_crate)]</font>: Received [crate_count] crates.<BR>"
 			points += crate_count * points_per_crate
 
-		if(tech_count)
-			centcom_message += "<font color=green>+[round(tech_count * points_per_tech)]</font>: Received [tech_count]  levels of new technology.<BR>"
-			points += tech_count * points_per_tech
-
-		if(plant_count)
-			centcom_message += "<font color=green>+[round(plant_count/plant_per_point)]</font>: Received [plant_count] units of grown produce.<BR>"
-			points += round(plasma_count / plasma_per_point)
 
 	//Buyin
 	proc/buy()


### PR DESCRIPTION
Cleans up and refractors my old data disk selling code
Removes my selling plants code, as it is outdated thanks to the more interesting Selling Mutant Seeds code.

Reminder: All data levels on a disk greater then the previously sent ones give six points per level. Empty or first level disks give you no points. 
