### PR TITLE
Thermite no longer has 80% chance to burn forever

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -314,8 +314,6 @@
 		F.add_hiddenprint(user)
 		spawn(max(100,300-thermite))
 			if(O)	qdel(O)
-	else if(prob(80))
-		ReplaceWithLattice()
 	else
 		thermite = 0
 		spawn(50)


### PR DESCRIPTION
A stray line from the old meteorhit code wandered in. Since this proc
runs once per thermite activation, there was only 20% chance to run the
code that deletes the overlay and turns the thermitedness stat to False.
Fixes issue #99 
