### PR TITLE
Artifact balances/bugfixes

### DIFF
--- a/code/modules/mining/artifact/artifacts.dm
+++ b/code/modules/mining/artifact/artifacts.dm
@@ -160,6 +160,10 @@ var/global/ankh = 0 // only one can spawn
 				if(!checkfail(A_HEAT,1))
 					user << "<span class='notice'>\The [src] appears to react to the heat of \the [WT].</span>"
 					playsound(get_turf(src),'sound/items/welder.ogg',70,1)
+	else if(istype(W,/obj/item/device/activator))
+		if(!activated)
+			stimnum = 1
+			activate()
 	else
 		if(!activated)
 			if(W.force)
@@ -417,16 +421,18 @@ var/global/ankh = 0 // only one can spawn
 			title = "cell"
 
 /obj/item/artifact/proc/update_icons()
-	if(!reverse)
-		if(!density && cooldown == 1)
+	if(!reverse && usetype == A_CONSTANT)
+		icon_state = "[title][on]"
+	else if(!reverse)
+		if(cooldown == 1)
 			icon_state = "[title]0"
 		else
 			icon_state = "[title][on]"
 	else
-		if(cooldown == 1)
+		if(cooldown == 1 && on)
 			icon_state = "[title]1"
 		else
-			icon_state = "[title][on]"
+			icon_state = "[title]0"
 
 /obj/item/artifact/examine()
 	set src in usr

--- a/code/modules/mining/artifact/misc.dm
+++ b/code/modules/mining/artifact/misc.dm
@@ -9,7 +9,7 @@
 	desc = "It flickers in and out of reality, warping the mind."
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "forgotten"
-	alpha = 50
+	alpha = 30
 	maxHealth = 20
 	health = 20
 	emote_hear = list("moans","wails","whispers")
@@ -23,17 +23,19 @@
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	faction = "cult"
 
-/mob/living/simple_animal/hostile/retaliate/shadow/New()
-	..()
+/mob/living/simple_animal/hostile/retaliate/shadow/proc/creation(var/lifespan = 1500)
 	visible_message("<span class='warning'>A shadow appears.</span>")
-	spawn(1500)
+	spawn(lifespan)
 		visible_message("<span class='warning'>The shadow fades away.</span>")
 		qdel(src)
 
 /mob/living/simple_animal/hostile/retaliate/shadow/Life()
 	..()
-	for(var/mob/living/carbon/human/H in range(3,src))
-		H.adjustBrainLoss(rand(0.5,1))
+	for(var/mob/living/carbon/human/H in range(2,src))
+		if(prob(20))
+			H.hallucination += rand(10,20)
+			if(prob(55))
+				H << "<span class='warning'>You feel a trickle of insanity...</span>"
 
 ///////////
 // LIGHT //
@@ -43,6 +45,8 @@
 	name = "dancing lights"
 	desc = "So bright, so ethereal."
 	density = 0
+	layer = 5 // Over everything
+	alpha = 125 // Semi-transparent
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state ="ice_1"
 	pass_flags = PASSGLASS | PASSGRILLE
@@ -60,9 +64,7 @@
 	if(!target)
 		qdel(src)
 	else
-		x = target.x
-		y = target.y
-		z = target.z
+		walk_towards(src, target, 0)
 
 /obj/effect/artlight/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 1
@@ -308,6 +310,27 @@
 
 	log_admin("[key_name(usr)] rerolled all artifacts.")
 	message_admins("[key_name_admin(usr)] rerolled all artifacts.)", 1)
+
+///////////////
+// ACTIVATOR //
+///////////////
+
+// For admin purposes
+
+/obj/item/device/activator
+	name = "activator"
+	desc = "It broadcasts a frequency that activates artifacts."
+	icon_state = "atmos"
+	item_state = "analyzer"
+	w_class = 2.0
+	flags = CONDUCT
+	slot_flags = SLOT_BELT
+	throwforce = 0
+	throw_speed = 3
+	throw_range = 7
+	m_amt = 30
+	g_amt = 20
+	origin_tech = "magnets=1;engineering=1"
 
 ///////////////
 // GUN STUFF //


### PR DESCRIPTION
Changelog:
- Improved orb of light tracking and movement, increased layer and
  decreased alpha
- Extinguishing artifact now extinguishes humans
- Extinguishing artifact now cools down humans
- Fixed some update_icons issues
- Fixed on-click saplife ability
- Fixed wormhole runtime errors caused by trying to pick tiles from an
  empty list
- Decreased shadow mob lifespan
- Decreased shadow mob visibility
- Shadow mobs now cause hallucinations instead of brain damage
- Nightmare ability no longer causes brain damage
- Added a message when detection/location ability doesn't detect any
  nearby artifacts
- Added small cooldown for detection/location ability
- Added on-click pull/push ability cooldown
- A message now appears when healed by healing ability
- The melee ability now exclusively activates upon melee attack
- Melee ability now displays an attack message on hit
- The dirt ability now has a chance to create xenoblood
- Fixed forcewall length
- Decreased forcewall ability cooldown
- Fixed some abilities not working with ranged artifacts
