### PR TITLE
Tiny Artifact Code Standarding

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -86,7 +86,7 @@ var/global/xartnum = 0 // Extra artifact number. Used to prevent too many extra 
 
 /obj/effect/landmark/artifact/New()
 	..()
-	if(prob(50)-(xartnum*8))
+	if(prob(max(0,50-(xartnum*8))))
 		new /obj/item/artifact(loc)
 		xartnum++
 	qdel(src)

--- a/code/modules/surgery/limb augmentation.dm
+++ b/code/modules/surgery/limb augmentation.dm
@@ -18,8 +18,7 @@
 	time = 32
 	var/obj/item/organ/limb/L = null // L because "limb"
 	allowed_organs = list("r_arm","l_arm","r_leg","l_leg","chest","head")
-
-
+	allow_surgery_multitool = 0
 
 /datum/surgery_step/add_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	L = new_organ
@@ -27,32 +26,6 @@
 		user.visible_message("<span class ='notice'>[user] begins to augment [target]'s [parse_zone(user.zone_sel.selecting)].</span>")
 	else
 		user.visible_message("<span class ='notice'>[user] looks for [target]'s [parse_zone(user.zone_sel.selecting)].</span>")
-
-/datum/surgery_step/add_limb/try_op(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	// So you can't augment someone with a surgery artifact.
-	var/success = 0
-	if(accept_hand)
-		if(!tool)
-			success = 1
-	if(accept_any_item)
-		if(tool && tool_check(user, tool))
-			success = 1
-	else
-		for(var/path in implements)
-			if(istype(tool, path))
-				implement_type = path
-				if(tool_check(user, tool))
-					success = 1
-
-	if(success)
-		if(target_zone == surgery.location)
-			if(get_location_accessible(target, target_zone))
-				initiate(user, target, target_zone, tool, surgery)
-				return 1
-			else
-				user << "<span class='notice'>You need to expose [target]'s [target_zone] to perform surgery on it!</span>"
-				return 1
-	return 0
 
 //ACTUAL SURGERIES
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -6,6 +6,7 @@
 	var/time = 10					//how long does the step take?
 	var/new_organ = null 			//Used for multilocation operations
 	var/list/allowed_organs = list()//Allowed organs, see Handle_Multi_Loc below - RR
+	var/allow_surgery_multitool = 1
 
 
 /datum/surgery_step/proc/try_op(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -16,7 +17,7 @@
 	if(accept_any_item)
 		if(tool && tool_check(user, tool))
 			success = 1
-	else if(istype(tool,/obj/item/artifact))
+	else if(allow_surgery_multitool && istype(tool,/obj/item/artifact))
 		var/obj/item/artifact/A = tool
 		if(A.power == A_SURGERY)
 			success = 1


### PR DESCRIPTION
- Reworked artifact spawning probability curve. Probability changes properly now.
- Removed copy pasted code in surgery, added an allow_surgery_multitool var to surgery steps, which can be used later by new items, not just artifacts.
