### PR TITLE
Nuke Scaling Moved To Config [wip]

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -76,6 +76,7 @@
 
 	var/traitor_scaling_coeff = 6		//how much does the amount of players get divided by to determine traitors
 	var/changeling_scaling_coeff = 7	//how much does the amount of players get divided by to determine changelings
+	var/nukeop_scaling_coeff = 0		//how much does the amount of players get divided by to determine nuclear operative agents. Disabled by default
 
 	var/traitor_objectives_amount = 2
 	var/protect_roles_from_antagonist = 0// If security and such can be traitor/cult/other
@@ -349,6 +350,8 @@
 					config.changeling_scaling_coeff	= text2num(value)
 				if("traitor_objectives_amount")
 					config.traitor_objectives_amount = text2num(value)
+				if("nukeop_scaling_coeff")
+					config.nukeop_scaling_coeff = text2num(value)
 				if("probability")
 					var/prob_pos = findtext(value, " ")
 					var/prob_name = null

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -40,8 +40,8 @@
 	else
 		agent_number = antag_candidates.len
 
-	agent_number = min(agent_number , 1+round((n_players)/(nukeop_scaling_coeff))) //up to five, or one for every five crewmembers, whichever is smaller
-
+	if(config.nukeop_scaling_coeff)
+		agent_number = min(agent_number , round((n_players)/(nukeop_scaling_coeff) + 2))
 
 	if(agent_number >= n_players)
 		agent_number = n_players/2

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -15,7 +15,6 @@
 	uplink_uses = 10
 
 	var/const/agents_possible = 5 //If we ever need more syndicate agents.
-	var/const/nukeop_scaling_coeff = 11 //how much does the amount of players get divided by to determine operatives. Six players means one operative versus five crewmembers
 	var/const/waittime_l = 600 //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
 
@@ -41,7 +40,7 @@
 		agent_number = antag_candidates.len
 
 	if(config.nukeop_scaling_coeff)
-		agent_number = min(agent_number , round((n_players)/(nukeop_scaling_coeff) + 2))
+		agent_number = min(agent_number , round((n_players)/(config.nukeop_scaling_coeff) + 2))
 
 	if(agent_number >= n_players)
 		agent_number = n_players/2

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -113,6 +113,7 @@ SHUTTLE_REFUEL_DELAY 12000
 ## Set to 0 to disable scaling and use default numbers instead.
 TRAITOR_SCALING_COEFF 6
 CHANGELING_SCALING_COEFF 7
+NUKEOP_SCALING_COEFF 11
 
 # The number of objectives traitors get.
 # Not including escaping/hijacking.


### PR DESCRIPTION
 The amount of nuke ops is now based on the config file's setting. The base value is zero in-game, which means No Scaling. 
I have included a config file set to 11, our old setting. 
Increased the minimum number of operatives by one. Maximum is still five.
