### PR TITLE
Only blunt weapons break bones

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1028,8 +1028,8 @@
 
 	var/bloody = 0
 
-	if(I.force > 1 && I.damtype == BRUTE)
-		var/breakchance = ( I.force / 4 ) * I.w_class
+	if(I.force > 1 && I.damtype == BRUTE && !is_sharp(I))
+		var/breakchance = ( I.force / 3 ) * I.w_class
 		if(armor > 0)
 			breakchance *= (100 / armor)
 


### PR DESCRIPTION
This helps differentiate blunt and sharp items, with regards to the upcoming dismemberment update, makes items like eswords less extremely powerful, and makes items like the nullrod a bit more unique this way.
Also increases the breakage chance to compensate.
E: ugh i messed up the commits
