### PR TITLE
Protect HoP

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -97,6 +97,7 @@
 	var/traitor_objectives_amount = 2
 	var/protect_roles_from_antagonist = 0// If security and such can be traitor/cult/other
 	var/protect_captain_from_antagonist = 0
+	var/protect_hop_from_antagonist = 0
 	var/protect_assistant_from_antagonist = 0 //If assistants can be traitor/cult/other
 	var/enforce_human_authority = 0		//If non-human species are barred from joining as a head of staff
 	var/allow_latejoin_antagonists = 0 	// If late-joining players can be traitor/changeling
@@ -455,6 +456,9 @@
 
 				if("protect_captain_from_antagonist")
 					config.protect_captain_from_antagonist	= 1
+
+				if("protect_hop_from_antagonist")
+					config.protect_hop_from_antagonist	= 1
 
 				if("protect_assistant_from_antagonist")
 					config.protect_assistant_from_antagonist	= 1

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -45,6 +45,9 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	else if(config.protect_captain_from_antagonist)
 		restricted_jobs += "Captain"
 
+	if(config.protect_hop_from_antagonist)
+		restricted_jobs += "Head of Personnel"
+
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -81,6 +81,11 @@ Made by Xhuis
 /datum/game_mode/shadowling/pre_setup()
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
+	else if(config.protect_captain_from_antagonist)
+		restricted_jobs += "Captain"
+
+	if(config.protect_hop_from_antagonist)
+		restricted_jobs += "Head of Personnel"
 
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -43,6 +43,9 @@
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
+	if(config.protect_hop_from_antagonist)
+		restricted_jobs += "Head of Personnel"
+
 	var/num_traitors = 1
 
 	if(config.traitor_scaling_coeff)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -170,6 +170,10 @@ TRAITOR_OBJECTIVES_AMOUNT 2
 ## being most antagonists.
 #PROTECT_CAPTAIN_FROM_ANTAGONIST
 
+# Uncomment to prohibit the head of personnel from
+## being most antagonists.
+#PROTECT_HOP_FROM_ANTAGONIST
+
 
 
 ## Uncomment to prohibit assistants from becoming most antagonists.


### PR DESCRIPTION
By popular demand a config option that protects the hop from being an
antagonist. Defaults to off, as per standard, but many people would like
it to be turned on.
